### PR TITLE
Updated to disableRemoteMethodByName

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function (Model, options) {
     methods.concat(relationMethods).forEach(function (method) {
       var methodName = method.name
       if (methodsToExpose.indexOf(methodName) < 0) {
-        Model.disableRemoteMethod(methodName, method.isStatic)
+        Model.disableRemoteMethodByName(methodName)
       }
     })
   }


### PR DESCRIPTION
loopback deprecated Model.disableRemoteMethod is deprecated. Use Model.disableRemoteMethodByName instead. node_modules\loopback-mixin-whitelist\index.js:34:15

See also: https://github.com/digitalsadhu/loopback-component-jsonapi/issues/177